### PR TITLE
Remove teardown function from Platform trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ extern crate winrt;
 trait Platform {
     fn setup() -> Self;
     fn notify(msg_title: &str, msg_body: &str);
-    fn teardown(self);
 }
 
 #[cfg(target_os = "windows")]
@@ -71,8 +70,11 @@ impl Platform for Windows {
         .show(&*toast)
         .unwrap();
     }
+}
 
-    fn teardown(self) {
+#[cfg(target_os = "windows")]
+impl Drop for Windows {
+    fn drop(self) {
         self.0.uninit();
     }
 }
@@ -91,8 +93,6 @@ impl Platform for MacOs {
         mac_notification_sys::set_application(&bundle).unwrap();
         mac_notification_sys::send_notification(msg_title, &None, msg_body, &None).unwrap();
     }
-
-    fn teardown(self) {}
 }
 
 #[cfg(target_os = "linux")]
@@ -111,8 +111,6 @@ impl Platform for Linux {
             .show()
             .unwrap();
     }
-
-    fn teardown(self) {}
 }
 
 #[cfg(target_os = "windows")]
@@ -125,5 +123,4 @@ type CurrPlatform = Linux;
 pub fn notify(msg_title: &str, msg_body: &str) {
     let p = CurrPlatform::setup();
     CurrPlatform::notify(msg_title, msg_body);
-    p.teardown();
 }


### PR DESCRIPTION
Drop is implemented for platforms, that require teardown logic (only
windows)

Closes #6 (cannot test since I do not own a Windows license)