### PR TITLE
Return concrete type instead of trait object from notifica::notify

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 
-fn main() -> Result<(), Box<Error>> {
-    notifica::notify("Hello", "World! 🌍")
+fn main() -> Result<(), Box<dyn Error>> {
+    notifica::notify("Hello", "World! 🌍")?;
+    Ok(())
 }


### PR DESCRIPTION
This wraps the existing `enum Error` in a newtype to prevent the exposure of implementation details.