### PR TITLE
Fix panic on macOS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,9 @@ impl Platform for Windows {
 }
 
 #[cfg(target_os = "macos")]
+static APP_SET: std::sync::Once = std::sync::Once::new();
+
+#[cfg(target_os = "macos")]
 struct MacOs;
 
 #[cfg(target_os = "macos")]
@@ -174,8 +177,10 @@ impl Platform for MacOs {
     }
 
     fn notify(msg_title: &str, msg_body: &str) -> Result<(), ErrorRepr> {
-        let bundle = mac_notification_sys::get_bundle_identifier("Script Editor").unwrap();
-        mac_notification_sys::set_application(&bundle).unwrap();
+        APP_SET.call_once(|| {
+            let bundle = mac_notification_sys::get_bundle_identifier("Script Editor").unwrap();
+            mac_notification_sys::set_application(&bundle).unwrap();
+        });
         mac_notification_sys::send_notification(msg_title, &None, msg_body, &None).unwrap();
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,14 +173,14 @@ struct MacOs;
 #[cfg(target_os = "macos")]
 impl Platform for MacOs {
     fn setup() -> Self {
-        MacOs
-    }
-
-    fn notify(msg_title: &str, msg_body: &str) -> Result<(), ErrorRepr> {
         APP_SET.call_once(|| {
             let bundle = mac_notification_sys::get_bundle_identifier("Script Editor").unwrap();
             mac_notification_sys::set_application(&bundle).unwrap();
         });
+        MacOs
+    }
+
+    fn notify(msg_title: &str, msg_body: &str) -> Result<(), ErrorRepr> {
         mac_notification_sys::send_notification(msg_title, &None, msg_body, &None).unwrap();
         Ok(())
     }


### PR DESCRIPTION
`mac_notification_sys::set_application` panics if run more than once -- and this runs every time `notify` is run. The issue from that is obvious.